### PR TITLE
Added key bindings for panning the screen

### DIFF
--- a/virus/virus.pde
+++ b/virus/virus.pde
@@ -375,21 +375,19 @@ void keyActions() {
   }
 }
 void mouseWheel(MouseEvent event) {
+  double ZOOM_F = 1.05;
+  double thisZoomF = 1;
   float e = event.getCount();
-  if((camS > 50 || e < 0.0) && (camS < 1000 || e > 0.0)) {
-    double ZOOM_F = 1.05;
-    double thisZoomF = 1;
-    if(e > 0.0){
-      thisZoomF = 1/ZOOM_F;
-    }else if(e < 0.0){
-      thisZoomF = ZOOM_F;
-    }
-    double worldX = mouseX/camS+camX;
-    double worldY = mouseY/camS+camY;
-    camX = (camX-worldX)/thisZoomF+worldX;
-    camY = (camY-worldY)/thisZoomF+worldY;
-    camS *= thisZoomF;
+  if(e == 1){
+    thisZoomF = 1/ZOOM_F;
+  }else{
+    thisZoomF = ZOOM_F;
   }
+  double worldX = mouseX/camS+camX;
+  double worldY = mouseY/camS+camY;
+  camX = (camX-worldX)/thisZoomF+worldX;
+  camY = (camY-worldY)/thisZoomF+worldY;
+  camS *= thisZoomF;
 }
 double euclidLength(double[] coor){
   return Math.sqrt(Math.pow(coor[0]-coor[2],2)+Math.pow(coor[1]-coor[3],2));

--- a/virus/virus.pde
+++ b/virus/virus.pde
@@ -362,16 +362,16 @@ void keyReleased() {
 }
 void keyActions() {
   if(leftDown) {
-    camX -= KEY_STRIDE / (camS) + 0.01;
+    camX -= KEY_STRIDE/camS + 0.01;
   }
   if(rightDown) {
-    camX += KEY_STRIDE / (camS) + 0.01;
+    camX += KEY_STRIDE/camS + 0.01;
   }
   if(upDown) {
-    camY -= KEY_STRIDE / (camS) + 0.01;
+    camY -= KEY_STRIDE/camS + 0.01;
   }
   if(downDown) {
-    camY += KEY_STRIDE / (camS) + 0.01;
+    camY += KEY_STRIDE/camS + 0.01;
   }
 }
 void mouseWheel(MouseEvent event) {

--- a/virus/virus.pde
+++ b/virus/virus.pde
@@ -91,10 +91,16 @@ double camX = 0;
 double camY = 0;
 double MIN_CAM_S = ((float)W_H)/WORLD_SIZE;
 double camS = MIN_CAM_S;
+double KEY_STRIDE = 5;
+boolean leftDown = false;
+boolean rightDown = false;
+boolean upDown = false;
+boolean downDown = false;
 void draw(){
   doParticleCountControl();
   iterate();
   detectMouse();
+  keyActions();
   drawBackground();
   drawCells();
   drawParticles();
@@ -325,6 +331,48 @@ void detectMouse(){
     arrowToDraw = null;
   }
   wasMouseDown = mousePressed;
+}
+void keyPressed() {
+  if(key == 'a' || (key == CODED && keyCode == LEFT)) {
+    leftDown = true;
+  } 
+  if(key == 'd' || (key == CODED && keyCode == RIGHT)) {
+    rightDown = true;
+  } 
+  if(key == 'w' || (key == CODED && keyCode == UP)) {
+    upDown = true;
+  } 
+  if(key == 's' || (key == CODED && keyCode == DOWN)) {
+    downDown = true;
+  }
+}
+void keyReleased() {
+  if(key == 'a' || (key == CODED && keyCode == LEFT)) {
+    leftDown = false;
+  } 
+  if(key == 'd' || (key == CODED && keyCode == RIGHT)) {
+    rightDown = false;
+  } 
+  if(key == 'w' || (key == CODED && keyCode == UP)) {
+    upDown = false;
+  } 
+  if(key == 's' || (key == CODED && keyCode == DOWN)) {
+    downDown = false;
+  }
+}
+void keyActions() {
+  if(leftDown) {
+    camX -= KEY_STRIDE / (camS) + 0.01;
+  }
+  if(rightDown) {
+    camX += KEY_STRIDE / (camS) + 0.01;
+  }
+  if(upDown) {
+    camY -= KEY_STRIDE / (camS) + 0.01;
+  }
+  if(downDown) {
+    camY += KEY_STRIDE / (camS) + 0.01;
+  }
 }
 void mouseWheel(MouseEvent event) {
   double ZOOM_F = 1.05;

--- a/virus/virus.pde
+++ b/virus/virus.pde
@@ -375,19 +375,21 @@ void keyActions() {
   }
 }
 void mouseWheel(MouseEvent event) {
-  double ZOOM_F = 1.05;
-  double thisZoomF = 1;
   float e = event.getCount();
-  if(e == 1){
-    thisZoomF = 1/ZOOM_F;
-  }else{
-    thisZoomF = ZOOM_F;
+  if((camS > 50 || e < 0.0) && (camS < 1000 || e > 0.0)) {
+    double ZOOM_F = 1.05;
+    double thisZoomF = 1;
+    if(e > 0.0){
+      thisZoomF = 1/ZOOM_F;
+    }else if(e < 0.0){
+      thisZoomF = ZOOM_F;
+    }
+    double worldX = mouseX/camS+camX;
+    double worldY = mouseY/camS+camY;
+    camX = (camX-worldX)/thisZoomF+worldX;
+    camY = (camY-worldY)/thisZoomF+worldY;
+    camS *= thisZoomF;
   }
-  double worldX = mouseX/camS+camX;
-  double worldY = mouseY/camS+camY;
-  camX = (camX-worldX)/thisZoomF+worldX;
-  camY = (camY-worldY)/thisZoomF+worldY;
-  camS *= thisZoomF;
 }
 double euclidLength(double[] coor){
   return Math.sqrt(Math.pow(coor[0]-coor[2],2)+Math.pow(coor[1]-coor[3],2));


### PR DESCRIPTION
Adds key binding of WASD and the arrow keys to pan around the scene as opposed to just being able to do so by dragging the mouse. Allows for panning the screen with precise horizontal, vertical, and diagonal travel as well as while having the UGO creator open.